### PR TITLE
Fix PEP8 code style violations, fix some shadowing of python internals

### DIFF
--- a/coc-tui
+++ b/coc-tui
@@ -8,16 +8,18 @@ import yaml
 import coc
 from coc.exceptions import *
 
-from tui import interface,t
+from tui import interface, t
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-D', '--debug')
     parser.add_argument('-p', '--player', nargs=1, default=None)
-# TODO: use os.fsencode() or something similar to make path name parsing os-agnostic
+# TODO: use os.fsencode() or something similar to make path name parsing
+#  os-agnostic
     parser.add_argument('-S', '--save-path', nargs=1, default='~/.coc/')
     parser.add_argument('--world-schema', nargs=1, default='classic/')
     args = parser.parse_args(sys.argv[1:])
 
-    coc.Session(world_path=args.world_schema, save_path=args.save_path, interface=interface).play()
+    coc.Session(world_path=args.world_schema, save_path=args.save_path,
+                interface=interface).play()
     print('Session exited!')

--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -1,9 +1,11 @@
 import os
 from abc import ABC
 
+
 class COCClass(ABC):
     """ Common base class for all CoC module classes
     """
+
 
 class Immutable(COCClass):
     """ Common base class for CoC subclasses that have properties which are
@@ -19,6 +21,7 @@ class Immutable(COCClass):
         else:
             super().__setattr__(key, value)
 
+
 class EventContext(Immutable):
     """ Common base class for world objects that have events associated with
     them. Used mainly to handle event loading.
@@ -32,5 +35,6 @@ class EventContext(Immutable):
             self._events_loaded = True
             return self.event_path
         return False
+
 
 from coc.session import Session

--- a/coc/exceptions.py
+++ b/coc/exceptions.py
@@ -4,11 +4,13 @@ class COCException(Exception):
     def __init__(self, msg=None, **kwargs):
         super().__init__(msg)
 
+
 class LoadError(COCException):
     """ Exception type for all logical issues with loading game state and assets
     """
     def __init__(self, msg=None):
         super().__init__(msg)
+
 
 class InterfaceException(COCException):
     """
@@ -16,11 +18,13 @@ class InterfaceException(COCException):
     def __init__(self, msg=None):
         super().__init__(msg)
 
+
 class ExitMenuException(InterfaceException):
     """ Exception type for backing out of a menu
     """
     def __init__(self, msg=None):
         super().__init__(msg)
+
 
 class InterfaceAPIError(InterfaceException):
     """ Exception type for backing out of a menu
@@ -28,11 +32,13 @@ class InterfaceAPIError(InterfaceException):
     def __init__(self, msg=None):
         super().__init__(msg)
 
+
 class NotPermittedError(COCException):
     """ Exception raised when inter-class permissions prevent an action
     """
     def __init__(self, msg=None):
         super().__init__(msg)
+
 
 class ImmutablePropertyError(NotPermittedError):
     """ Exception raised when trying to set immutable attributes on an
@@ -41,11 +47,13 @@ class ImmutablePropertyError(NotPermittedError):
     def __init__(self, attr, classname):
         super().__init__("``{0}.{1}`` is immutable after initialization")
 
+
 class SchemaError(COCException):
     """ Generic error for syntactic or structural issues with the world schema
     """
     def __init__(self, msg=None, **kwargs):
         super().__init__(msg)
+
 
 class ParseError(SchemaError):
     """ Raised when trying to parse an assignment or conditional expression
@@ -54,11 +62,13 @@ class ParseError(SchemaError):
     def __init__(self, expr, msg=None, **kwargs):
         super().__init__(msg, schema={"<expr>": expr})
 
+
 class ObjectNotFoundError(SchemaError):
     """ Raised when a request to an object registry fails to find something
     """
     def __init__(self, msg=None, **kwargs):
         super().__init__(msg)
+
 
 class StateNotFoundError(SchemaError):
     """ Raised when a query to the state index fails to match anything

--- a/coc/player/__init__.py
+++ b/coc/player/__init__.py
@@ -4,6 +4,7 @@ import copy
 
 from coc import *
 
+
 class Player(Immutable):
     """ Contains all state for an in-progress game, including world state, NPC
     interaction state, PC status effects and possessions, etc.
@@ -24,9 +25,11 @@ class Player(Immutable):
                 raise Exception()
             if state_path[2] not in self.state[state_path[0]][state_path[1]]:
                 raise Exception()
-            return copy.deepcopy(self.state[state_path[0]][state_path[1]][state_path[2]])
+            return copy.deepcopy(
+                self.state[state_path[0]][state_path[1]][state_path[2]])
         except IndexError as e:
             raise
+
     def set_state(self, state_path, value):
         pass
 
@@ -59,8 +62,8 @@ def load(save_file):
 
 
 # def create(name, world, interface):
-#     """ A factory function that creates a new player object from parameters and
-#     a world object.
+#     """ A factory function that creates a new player object from parameters
+#     and a world object.
 #     """
 #     race = interface.menu_choice(title='What race are you?',
 #             options=['human',

--- a/coc/session/__init__.py
+++ b/coc/session/__init__.py
@@ -6,7 +6,8 @@ from coc import COCClass
 from coc import world
 from coc import player as playerlib
 from coc.exceptions import *
-from coc.session import game_load,initialization
+from coc.session import game_load, initialization
+
 
 class Session(COCClass):
     """ Represents an interactive play session, used by various interfaces to
@@ -20,7 +21,8 @@ class Session(COCClass):
         self.player = None
         while not self.player:
             try:
-                self.save_file = game_load.select_save(os.path.expanduser(save_path))
+                self.save_file = game_load.select_save(
+                    os.path.expanduser(save_path))
                 self.player = self.load_player(self.save_file)
             except LoadError as e:
                 interface.print(str(e), buffer='flush')
@@ -31,10 +33,12 @@ class Session(COCClass):
         try:
             player = playerlib.load(save_file)
 # FIXME: world ID generation is broken. the same world generates multiple IDs.
-# check the world ID scheme generating code, deepcopy may not be a stable operation.
-            #if player.world_id != self.world.id:
-            #    self.interface.prompt('')
-            #    raise LoadError("Save file does not match the selected world!")
+#  check the world ID scheme generating code,
+#  deepcopy may not be a stable operation.
+            # if player.world_id != self.world.id:
+            #     self.interface.prompt('')
+            #     raise LoadError(
+            #             "Save file does not match the selected world!")
             return player
         except LoadError as e:
             raise LoadError(
@@ -46,21 +50,23 @@ class Session(COCClass):
         except FileNotFoundError:
             player = self.new_player()
             player.save(save_file)
-            with open(os.path.join(os.path.dirname(self.save_file), 'saves.yaml'), 'r') as file:
+            with open(os.path.join(os.path.dirname(self.save_file),
+                                   'saves.yaml'), 'r') as file:
                 saves = yaml.load(file.read())
             assert player.name not in saves
             saves[player.name] = self.save_file
-            with open(os.path.join(os.path.dirname(self.save_file), 'saves.yaml'), 'w') as file:
+            with open(os.path.join(os.path.dirname(self.save_file),
+                                   'saves.yaml'), 'w') as file:
                 file.write(yaml.dump(saves))
             return player
-
 
     def save_player(self, save_file=None):
         try:
             self.player.save(save_file)
         except AttributeError as e:
             if str(e) == "'NoneType' object has no attribute 'endswith'":
-# tried to check if a nonexistent path had the right file extension
+                # tried to check if a nonexistent path had
+                # the right file extension
                 self.player.save(self.save_file)
             else:
                 raise
@@ -68,12 +74,15 @@ class Session(COCClass):
     def new_player(self):
         state_template = self.world.get_state_template()
         initial_state = dict()
-        initial_state['pc'] = initialization.initialize_pc_state(state_template['pc'], self.interface)
-        initial_state['game'] = initialization.initialize_game_state(state_template['game'], self.interface)
+        initial_state['pc'] = initialization.initialize_pc_state(
+            state_template['pc'], self.interface)
+        initial_state['game'] = initialization.initialize_game_state(
+            state_template['game'], self.interface)
         player_name = os.path.split(self.save_file)[-1]
         if player_name.endswith('csf'):
             player_name = os.path.splitext(player_name)[0]
-        new_player = playerlib.Player(player_name, self.world.id, initial_state, None)
+        new_player = playerlib.Player(player_name, self.world.id,
+                                      initial_state, None)
         return new_player
 
     def play(self):
@@ -81,4 +90,3 @@ class Session(COCClass):
         import pprint
         pprint.pprint(self.player.state)
         locale = self.player.get_state(['pc', 'strings', 'initial_locale'])
-

--- a/coc/session/game_load.py
+++ b/coc/session/game_load.py
@@ -5,16 +5,18 @@ from coc.exceptions import *
 
 from tui import interface as i
 
+
 def select_save(save_path):
-# Read existing save files to populate the menu
+    # Read existing save files to populate the menu
     try:
         with open(os.path.join(save_path, 'saves.yaml'), 'r') as file:
             saves = yaml.load(file.read())
     except (yaml.YAMLError, KeyError) as e:
         raise LoadError("Unable to load your saves.\n"
-                "saves.yaml is corrupted!") from e
+                        "saves.yaml is corrupted!") from e
     except FileNotFoundError as e:
-# No save.yaml yet on the target path. Assume this is an uninitialized save path.
+        # No save.yaml yet on the target path.
+        # Assume this is an uninitialized save path.
         saves = {}
         if not os.path.isdir(save_path):
             os.mkdir(save_path)
@@ -25,7 +27,8 @@ def select_save(save_path):
     while True:
         save_name = i.menu_choice(menu, title="Select a save!")
         if save_name == '< new game >':
-            name = i.get_line(prompt="Beginning a new game! What will we call you?")
+            name = i.get_line(
+                prompt="Beginning a new game! What will we call you?")
             if not name:
                 i.error("Empty names are not allowed!")
             elif name in saves:

--- a/coc/session/initialization.py
+++ b/coc/session/initialization.py
@@ -2,6 +2,7 @@ from coc.world.event import get_by_id as get_event_by_id
 from coc.world.locale import get_by_id as get_locale_by_id
 from coc.exceptions import *
 
+
 def initialize_pc_state(state_template, interface):
     initial_state = {
             'flags': dict(),
@@ -46,7 +47,7 @@ def initialize_pc_state(state_template, interface):
         if 'flags' in state_template['statics']:
             initial_state['flags'].update(
                     {
-                        key:bool(state_template['statics']['flags'][key])
+                        key: bool(state_template['statics']['flags'][key])
                         for key in
                         state_template['statics']['flags']
                         }
@@ -54,7 +55,7 @@ def initialize_pc_state(state_template, interface):
         if 'counters' in state_template['statics']:
             initial_state['counters'].update(
                     {
-                        key:int(state_template['statics']['counters'][key])
+                        key: int(state_template['statics']['counters'][key])
                         for key in
                         state_template['statics']['counters']
                         }
@@ -62,7 +63,7 @@ def initialize_pc_state(state_template, interface):
         if 'numbers' in state_template['statics']:
             initial_state['numbers'].update(
                     {
-                        key:float(state_template['statics']['numbers'][key])
+                        key: float(state_template['statics']['numbers'][key])
                         for key in
                         state_template['statics']['numbers']
                         }
@@ -70,7 +71,7 @@ def initialize_pc_state(state_template, interface):
         if 'strings' in state_template['statics']:
             initial_state['strings'].update(
                     {
-                        key:str(state_template['statics']['strings'][key])
+                        key: str(state_template['statics']['strings'][key])
                         for key in
                         state_template['statics']['strings']
                         }
@@ -84,17 +85,20 @@ def initialize_pc_state(state_template, interface):
         if 'counters' in state_template['choices']:
             for key in state_template['choices']['counters']:
                 initial_state['counters'][key] = interface.get_quantity(
-                        text=state_template['choices']['counters'][key]['prompt'],
-                        max=int(state_template['choices']['counters'][key]['max']),
-                        min=0,
+                        text=
+                        state_template['choices']['counters'][key]['prompt'],
+                        max_=
+                        int(state_template['choices']['counters'][key]['max']),
+                        min_=0,
                         autoround=False
                         )
         if 'numbers' in state_template['choices']:
             for key in state_template['choices']['numbers']:
                 initial_state['numbers'][key] = interface.get_quantity(
-                        text=state_template['choices']['numbers'][key]['prompt'],
-                        max=state_template['choices']['numbers'][key]['max'],
-                        min=state_template['choices']['numbers'][key]['min'],
+                        text=
+                        state_template['choices']['numbers'][key]['prompt'],
+                        max_=state_template['choices']['numbers'][key]['max'],
+                        min_=state_template['choices']['numbers'][key]['min'],
                         autoround=False,
                         is_float=True
                         )
@@ -102,9 +106,11 @@ def initialize_pc_state(state_template, interface):
             for key in state_template['choices']['strings']:
                 initial_state['strings'][key] = interface.menu_choice(
                         state_template['choices']['strings'][key]['choices'],
-                        title=state_template['choices']['strings'][key]['prompt']
+                        title=
+                        state_template['choices']['strings'][key]['prompt']
                         )
     return initial_state
+
 
 def initialize_game_state(state_template, interface):
     return {}

--- a/coc/world/__init__.py
+++ b/coc/world/__init__.py
@@ -5,8 +5,9 @@ import hashlib
 import copy
 
 from coc import *
-from coc.world import npc,monster,conditional,event,town,dungeon
+from coc.world import npc, monster, conditional, event, town, dungeon
 from coc.exceptions import *
+
 
 class World(Immutable):
     """ Contains a read-only (after load) record of all world content. Worlds
@@ -20,17 +21,19 @@ class World(Immutable):
         file_paths = glob.glob(os.path.join(schema_root, '*.yaml'))
         subdirs = [d.name for d in os.scandir(schema_root) if d.is_dir()]
         for subdir in subdirs:
-            file_paths.extend(glob.glob(os.path.join(schema_root, subdir, '*.yaml')))
+            file_paths.extend(glob.glob(
+                    os.path.join(schema_root, subdir, '*.yaml')))
         schema_sets = dict()
         for path in file_paths:
             with open(path, 'r') as file:
                 gen = yaml.load_all(file.read())
             schema_sets[path] = gen
-        for set in schema_sets.items():
-            for schema in set[1]:
-                self._load_schema(set[0], schema)
+        for set_ in schema_sets.items():
+            for schema in set_[1]:
+                self._load_schema(set_[0], schema)
 
-        self.id = hashlib.sha256(repr(self.get_state_template()).encode()).hexdigest()
+        self.id = hashlib.sha256(repr(self.get_state_template()).encode()
+                                 ).hexdigest()
         self.initialized = True
 
     def __setitem__(self, key, value):
@@ -44,15 +47,21 @@ class World(Immutable):
             world = copy.deepcopy(self.world_template)
         except AttributeError:
             world = {
-                    'npc': {obj.id: npc.state_template() for obj in npc.get_all()},
-                    'monster': {obj.id: obj.state_template() for obj in monster.get_all()},
-                    'town': {obj.id: obj.state_template() for obj in town.get_all()},
-                    'dungeon': {obj.id: obj.state_template() for obj in dungeon.get_all()},
+                    'npc': {obj.id: npc.state_template()
+                            for obj in npc.get_all()},
+                    'monster': {obj.id: obj.state_template()
+                                for obj in monster.get_all()},
+                    'town': {obj.id: obj.state_template()
+                             for obj in town.get_all()},
+                    'dungeon': {obj.id: obj.state_template()
+                                for obj in dungeon.get_all()},
                     }
             self.world_template = copy.deepcopy(world)
         ret = {
-                #'entities': {e.id: copy.deepcopy(e.state) for e in entity.get_all()},
-                #'locales': {l.id: copy.deepcopy(l.state) for l in locale.get_all()},
+                # 'entities': {
+                #         e.id: copy.deepcopy(e.state) for e in entity.get_all()},
+                # 'locales': {
+                #         l.id: copy.deepcopy(l.state) for l in locale.get_all()},
                 'pc': copy.deepcopy(self.pc_template),
                 'world': world,
                 'game': dict()
@@ -73,38 +82,47 @@ class World(Immutable):
             schema_handlers[schema['type']](schema)
         except KeyError as e:
             if e.args[0] == 'type':
-                raise SchemaError('unable to load schema from {0} with missing'
+                raise SchemaError(
+                        'unable to load schema from {0} with missing'
                         '``type`` parameter'.format(path), schema=schema) from e
             else:
-                raise SchemaError('unable to load schema from {0}. ``{1}`` is '
-                        'not a supported object type.'.format(path, schema['type']),
+                raise SchemaError(
+                        'unable to load schema from {0}. ``{1}`` is not a '
+                        'supported object type.'.format(path, schema['type']),
                         schema=schema) from e
 
     def _load_pc_schema(self, schema):
         try:
             self.pc_template = schema
         except KeyError as e:
-            raise SchemaError('pc state template missing required section '
-                    '``state``', schema=schema) from e
+            raise SchemaError(
+                    'pc state template missing required section ``state``',
+                    schema=schema) from e
 
     def _load_world_schema(self, schema):
         for item in schema:
             self.__setattr__(item, schema[item])
 
-    def _get_town_by_id(id):
-            return town.get_by_id(id)
+    @staticmethod
+    def _get_town_by_id(id_):
+        return town.get_by_id(id_)
 
-    def _get_dungeon_by_id(id):
-            return dungeon.get_by_id(id)
+    @staticmethod
+    def _get_dungeon_by_id(id_):
+        return dungeon.get_by_id(id_)
 
-    def _get_npc_by_id(id):
-            return npc.get_by_id(id)
+    @staticmethod
+    def _get_npc_by_id(id_):
+        return npc.get_by_id(id_)
 
-    def _get_monster_by_id(id):
-            return monster.get_by_id(id)
+    @staticmethod
+    def _get_monster_by_id(id_):
+        return monster.get_by_id(id_)
 
-    def _get_event_by_id(id):
-            return event.get_by_id(id)
+    @staticmethod
+    def _get_event_by_id(id_):
+        return event.get_by_id(id_)
+
 
 def load(schema_path):
     return World(schema_path)

--- a/coc/world/conditional.py
+++ b/coc/world/conditional.py
@@ -1,6 +1,7 @@
 from coc import Immutable
 from coc.exceptions import *
 
+
 class Expr(Immutable):
     """ 
     """
@@ -9,12 +10,13 @@ class Expr(Immutable):
         try:
             filters = [Filter(f) for f in expr.split('|')[1:]]
         except AttributeError as e:
-            raise ParseError("conditional expression expected but received ``{0}`` instead".format(type(expr)))
+            raise ParseError("conditional expression expected but "
+                             "received ``{0}`` instead".format(type(expr)))
         self.tokens = condition.split(expr.split('|')[0])
         self.arity = len(tokens - 1)
         try:
             if arity == 0:
-                self.test = lambda x,_: bool(x)
+                self.test = lambda x, _: bool(x)
                 args = [tokens[0]]
             elif arity == 1:
                 try:
@@ -25,7 +27,7 @@ class Expr(Immutable):
             elif arity == 2:
                 try:
                     self.test = binary[tokens[1]]
-                    args = [tokens[0],tokens[2]]
+                    args = [tokens[0], tokens[2]]
                 except KeyError:
                     self.test = funcs[tokens[0]]
                     args = tokens[1:]
@@ -33,7 +35,9 @@ class Expr(Immutable):
                 self.test = funcs[tokens[0]]
                 args = tokens[1:]
         except KeyError:
-            raise ParseError("no recognized operator or function in conditional expression ``{0}``".format(expr), expr=expr)
+            raise ParseError("no recognized operator or function in "
+                             "conditional expression ``{0}``".format(expr),
+                             expr=expr)
         self.initialized = True
 
     def test(self, state_func):
@@ -47,6 +51,7 @@ class Expr(Immutable):
             else:
                 args.append(arg)
         return self.test(args)
+
 
 class All(Immutable):
     """
@@ -62,6 +67,7 @@ class All(Immutable):
                 return False
         return True
 
+
 class Any(Immutable):
     """
     """
@@ -76,6 +82,7 @@ class Any(Immutable):
                 return True
         return False
 
+
 def parse(schema):
     if type(schema) == str:
         return Expr(schema)
@@ -87,7 +94,9 @@ def parse(schema):
         except KeyError:
             return All(schema['all'])
     else:
-        raise SchemaError("conditional schema tree is of an unrecognized type", schema=schema)
+        raise SchemaError("conditional schema tree is of an unrecognized type",
+                          schema=schema)
+
 
 unary = {
         '!': lambda x: not x[0]
@@ -101,7 +110,6 @@ binary = {
         '<': lambda x: x[0] < x[1],
         '<=': lambda x: x[0] <= x[1],
         '': lambda x: x[0] > x[1],
-        '>': lambda x: x[0] > x[1],
         }
 
 funcs = {

--- a/coc/world/dungeon.py
+++ b/coc/world/dungeon.py
@@ -3,6 +3,7 @@ from coc.exceptions import *
 
 dungeon_registry = dict()
 
+
 class Dungeon(Locale):
     """ Represents a hostile visitable location with a room map, where each room
     contains one or more events, incl. puzzles, fights, and loot.
@@ -10,12 +11,15 @@ class Dungeon(Locale):
     def __init__(self, schema):
         super().__init__(schema)
 
+
 def get_all():
     return dungeon_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return dungeon_registry[id]
+        return dungeon_registry[id_]
     except KeyError as e:
         raise ObjectNotFoundError("dungeon ``" + entity_id +
-                "`` was not found in the dungeon registry") from e
+                                  "`` was not found in the dungeon registry"
+                                  ) from e

--- a/coc/world/entity.py
+++ b/coc/world/entity.py
@@ -3,6 +3,7 @@ from coc.exceptions import *
 
 entity_registry = dict()
 
+
 class Entity(EventContext):
     """ Common base class for all interactable entities in the world (monsters,
     npcs, etc.)
@@ -17,26 +18,30 @@ class Entity(EventContext):
         try:
             self.id = schema['id']
             self.name = schema['name']
-            self.state['encounter_event_id'] = schema['state']['encounter_event']
+            self.state['encounter_event_id'] = \
+                schema['state']['encounter_event']
         except KeyError as e:
             raise SchemaError("entity schema missing required field ``{0}``"
-                    .format(e.args[0]), schema=schema) from e
+                              .format(e.args[0]), schema=schema) from e
         try:
             self.event_path = schema['load_events']
         except KeyError:
             self.event_path = None
-        for key,default in state_defaults.items():
+        for key, default in state_defaults.items():
             try:
-                self.state[key] = {id: default for id in schema[key][counters]}
+                self.state[key] = {
+                        id_: default for id_ in schema[key][counters]}
             except KeyError:
                 pass
+
 
 def get_all():
     return entity_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return entity_registry[id]
+        return entity_registry[id_]
     except KeyError as e:
-        raise ObjectNotFoundError("entity ``" + id +
-                "`` was not found in the entity registry") from e
+        raise ObjectNotFoundError("entity ``" + id_ + "`` was not found in the "
+                                                      "entity registry") from e

--- a/coc/world/event.py
+++ b/coc/world/event.py
@@ -3,12 +3,14 @@ from coc.exceptions import *
 
 event_registry = dict()
 
+
 class Event(Immutable):
     """ Represents a narrative sequence, including conditional components and
     usually terminating at a conditional branch, a fight, or a decision menu.
     """
     def __init__(self, schema):
         super().__init__()
+
         def load_sequence_item(seq_schema):
             try:
                 seq_type = seq_schema['type']
@@ -17,31 +19,38 @@ class Event(Immutable):
                 seq_schema = {'text': seq_schema}
             global sequence_constructors
             return sequence_constructors[seq_type](seq_schema)
-        self.sequence = [load_sequence_item(item) for item in schema['sequence']]
+
+        self.sequence = [
+                load_sequence_item(item) for item in schema['sequence']]
         global event_registry
         if schema['id'] in event_registry:
-            raise LoadError("attempted to load event ``{0}`` but that event id already exists".format(schema['id']))
+            raise LoadError("attempted to load event ``{0}`` but that event id "
+                            "already exists".format(schema['id']))
         event_registry[schema['id']] = self
         self.initialized = True
 
-
     def run(self, state):
         seq = self.sequence
+
         def _generator():
             for item in seq:
                 if item.check_condition(state):
                     yield item
         return _generator
 
+
 def get_all():
     return event_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return event_registry[id]
+        return event_registry[id_]
     except KeyError as e:
         raise ObjectNotFoundError("event ``" + entity_id +
-                "`` was not found in the event registry") from e
+                                  "`` was not found in the event registry"
+                                  ) from e
+
 
 class EventSequenceItem(Immutable):
     """ Parent class for all event sequence items - represents a single step in
@@ -57,6 +66,7 @@ class EventSequenceItem(Immutable):
         else:
             return self.condition.test(getfunc)
 
+
 class EventText(EventSequenceItem):
     """ An event sequence item containing a block of text. This is the core
     event sequence type for game content.
@@ -69,6 +79,7 @@ class EventText(EventSequenceItem):
     def do(self, interface, setfunc):
         interface.print(self.text)
 
+
 class EventBranch(EventSequenceItem):
     """ 
     """
@@ -78,6 +89,7 @@ class EventBranch(EventSequenceItem):
 
     def do(self, interface, setfunc):
         pass
+
 
 class EventModifyResource(EventSequenceItem):
     """ 
@@ -89,6 +101,7 @@ class EventModifyResource(EventSequenceItem):
     def do(self, interface, setfunc):
         pass
 
+
 class EventPrompt(EventSequenceItem):
     """ 
     """
@@ -99,6 +112,7 @@ class EventPrompt(EventSequenceItem):
     def do(self, interface, setfunc):
         pass
 
+
 class EventSetDefaultEvent(EventSequenceItem):
     """ 
     """
@@ -108,6 +122,7 @@ class EventSetDefaultEvent(EventSequenceItem):
 
     def do(self, interface, setfunc):
         pass
+
 
 sequence_constructors = {
         'render_text': EventText,

--- a/coc/world/locale.py
+++ b/coc/world/locale.py
@@ -1,6 +1,7 @@
 from coc import EventContext
 from coc.exceptions import *
 
+
 class Locale(EventContext):
     """ Common base class for all visitable locations in the world, incl. towns,
     dungeons, and wilderness areas.
@@ -8,18 +9,20 @@ class Locale(EventContext):
     def __init__(self, schema):
         super().__init__()
 
+
 # TODO: Let's come up with a more elegant solution for this. Maybe it makes
 #   sense to have all locale subclasses register themselves in a shared locale
 #   registry instead, and come up with a scheme to derive the locale type.
 # Maye it makes more sense just to brute force search. Probably there won't be
 #   that many locales to handle.
-def get_by_id(id):
+def get_by_id(id_):
     try:
-        return get_town_by_id(id)
+        return get_town_by_id(id_)
     except ObjectNotFoundError:
         try:
-            return get_dungeon_by_id(id)
+            return get_dungeon_by_id(id_)
         except ObjectNotFoundError:
             pass
-        raise ObjectNotFoundError("locale ``" + id +
-                "`` was not found in the town or dungeon registry")
+        raise ObjectNotFoundError("locale ``" + id_ +
+                                  "`` was not found in the town or dungeon "
+                                  "registry")

--- a/coc/world/monster.py
+++ b/coc/world/monster.py
@@ -3,6 +3,7 @@ from coc.exceptions import *
 
 monster_registry = dict()
 
+
 class Monster(Entity):
     """ Common base class for all interactable entities in the world (monsters,
     """
@@ -13,15 +14,18 @@ class Monster(Entity):
             self.state['defeat_event_id'] = schema['state']['defeat_event']
         except KeyError as e:
             raise SchemaError("monster schema missing required field ``{0}``"
-                    .format(e.args[0]), schema=schema) from e
+                              .format(e.args[0]), schema=schema) from e
         self.initialized = True
+
 
 def get_all():
     return monster_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return monster_registry[id]
+        return monster_registry[id_]
     except KeyError as e:
         raise ObjectNotFoundError("monster ``" + entity_id +
-                "`` was not found in the monster registry") from e
+                                  "`` was not found in the monster registry"
+                                  ) from e

--- a/coc/world/npc.py
+++ b/coc/world/npc.py
@@ -3,6 +3,7 @@ from coc.exceptions import *
 
 npc_registry = dict()
 
+
 class NPC(Entity):
     """ Common base class for all interactable entities in the world (monsters,
     """
@@ -10,12 +11,14 @@ class NPC(Entity):
         super().__init__(schema)
         self.initialized = True
 
+
 def get_all():
     return npc_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return npc_registry[id]
+        return npc_registry[id_]
     except KeyError as e:
         raise ObjectNotFoundError("npc ``" + entity_id +
-                "`` was not found in the npc registry") from e
+                                  "`` was not found in the npc registry") from e

--- a/coc/world/town.py
+++ b/coc/world/town.py
@@ -3,6 +3,7 @@ from coc.exceptions import *
 
 town_registry = dict()
 
+
 class Town(Locale):
     """ Represents a peaceful, visitable location with one or more selectable
     events as stores, NPCs, etc.
@@ -18,11 +19,13 @@ class Town(Locale):
         try:
             self.id = schema['id']
         except KeyError:
-            raise SchemaError("tried to load town object with no id field", schema=schema)
+            raise SchemaError("tried to load town object with no id field",
+                              schema=schema)
         try:
             self.name = schema['name']
         except KeyError:
-            raise SchemaError("tried to load town object with no id field", schema=schema)
+            raise SchemaError("tried to load town object with no id field",
+                              schema=schema)
         if 'flags' in schema['state']:
             for flag in schema['state']['flags']:
                 try:
@@ -30,7 +33,7 @@ class Town(Locale):
                     self.state['flags'][pair[0]] = bool(pair[1])
                 except AttributeError:
                     self.state['flags'][flag] = False
-                except (TypeError,IndexError) as e:
+                except (TypeError, IndexError) as e:
                     raise SchemaError(
                             "malformed flag state parameter ``{0}`` in town "
                             "object (id ``{1}``)".format(pair[0], self.id),
@@ -42,7 +45,7 @@ class Town(Locale):
                     self.state['counters'][pair[0]] = int(pair[1])
                 except AttributeError:
                     self.state['counters'][counter] = 0
-                except (TypeError,IndexError) as e:
+                except (TypeError, IndexError) as e:
                     raise SchemaError(
                             "malformed counter state parameter ``{0}`` in town "
                             "object (id ``{1}``)".format(pair[0], self.id),
@@ -54,7 +57,7 @@ class Town(Locale):
                     self.state['numbers'][pair[0]] = bool(pair[1])
                 except AttributeError:
                     self.state['numbers'][number] = 0.0
-                except (TypeError,IndexError) as e:
+                except (TypeError, IndexError) as e:
                     raise SchemaError(
                             "malformed number state parameter ``{0}`` in town "
                             "object (id ``{1}``)".format(pair[0], self.id),
@@ -66,18 +69,21 @@ class Town(Locale):
                     self.state['strings'][pair[0]] = str(pair[1])
                 except AttributeError:
                     self.state['strings'][string] = ''
-                except (TypeError,IndexError) as e:
+                except (TypeError, IndexError) as e:
                     raise SchemaError(
                             "malformed string state parameter ``{0}`` in town "
                             "object (id ``{1}``)".format(pair[0], self.id),
                             schema=schema) from e
 
+
 def get_all():
     return town_registry.values()
 
-def get_by_id(id):
+
+def get_by_id(id_):
     try:
-        return town_registry[id]
+        return town_registry[id_]
     except KeyError as e:
         raise ObjectNotFoundError("town ``" + entity_id +
-                "`` was not found in the town registry") from e
+                                  "`` was not found in the town registry"
+                                  ) from e

--- a/tui/__init__.py
+++ b/tui/__init__.py
@@ -6,12 +6,13 @@ from blessed import Terminal
 from coc.exceptions import *
 
 t = Terminal()
-w = textwrap.TextWrapper(fix_sentence_endings = True)
+w = textwrap.TextWrapper(fix_sentence_endings=True)
 _pause_sequence = False
 in_fullscreen = True
 window_height = 0
 window_width = 0
 _screenbuffer = ''
+
 
 def _fullscreen(func):
     def _decorator(*args, **kwargs):
@@ -25,12 +26,14 @@ def _fullscreen(func):
             raise
     return _decorator
 
+
 def _get_geometry():
     global window_height
     global window_width
     window_height = t.height - 6
     window_width = t.width - 4
     w.width = window_width
+
 
 def _dump_buffer(func):
     def _decorator(*args, **kwargs):
@@ -39,10 +42,11 @@ def _dump_buffer(func):
         return func(*args, **kwargs)
     return _decorator
 
+
 def _clean_up_errors(func):
     def _decorator(*args, **kwargs):
         ret = func(*args, **kwargs)
-        with t.location(3,t.height-1):
+        with t.location(3, t.height-1):
             _echo(t.clear_eol)
         return ret
     return _decorator
@@ -97,7 +101,9 @@ class Interface:
         global _screenbuffer
         global window_height
         if buffer not in ['ignore', 'use', 'flush']:
-            raise InterfaceAPIError("Interface.print() optional kwarg ``buffer`` only takes the values 'use', 'ignore', 'flush'")
+            raise InterfaceAPIError(
+                "Interface.print() optional kwarg ``buffer`` only takes the "
+                "values 'use', 'ignore', 'flush'")
         if buffer == 'flush':
             _screenbuffer = ''
         self.blank_window()
@@ -121,7 +127,7 @@ class Interface:
                 with t.location(x=3, y=y):
                     _echo(t.clear_eol)
                     _echo(item)
-                y -=1
+                y -= 1
             if pause:
                 c = '_'
                 while c not in ' +-':
@@ -141,25 +147,25 @@ class Interface:
         def draw_menu(renderable):
             self.blank_window()
             rendered = [
-                    '({0}) - {1}'.format(a,b)
-                    for a,b in
+                    '({0}) - {1}'.format(a, b)
+                    for a, b in
                     renderable
                     ]
             self.prompt('Press a key to select. q to quit, - to scroll up, + to'
-                            'scroll down.')
+                        'scroll down.')
             y = 2
             for item in rendered:
-                with t.location(x=5,y=y):
+                with t.location(x=5, y=y):
                     _echo(t.clear_eol)
                     _echo(item)
-                y +=1
+                y += 1
         global window_height
         offset = 0
         if title:
             self.title(title)
         selection_keys = '0123456789abcdefghijklmnoprstuvwxyz'
         renderable = list(zip(selection_keys,
-            choices[offset:window_height+offset]))
+                              choices[offset:window_height+offset]))
         draw_menu(renderable)
         selection = None
         while True:
@@ -171,7 +177,7 @@ class Interface:
                 if offset < 0:
                     offset = 0
                 renderable = list(zip(selection_keys,
-                    choices[offset:window_height+offset]))
+                                      choices[offset:window_height+offset]))
                 draw_menu(renderable)
                 continue
             if c == '-':
@@ -179,7 +185,7 @@ class Interface:
                 if offset < 0:
                     offset = 0
                 renderable = list(zip(selection_keys,
-                    choices[offset:window_height+offset]))
+                                      choices[offset:window_height+offset]))
                 draw_menu(renderable)
                 continue
             if c == 'q':
@@ -191,7 +197,8 @@ class Interface:
 
     @_fullscreen
     @_clean_up_errors
-    def boolean_choice(self, text=None, prompt="Press (y) or (n) to choose.", title=None):
+    def boolean_choice(self, text=None, prompt="Press (y) or (n) to choose.",
+                       title=None):
         if title is not None:
             self.title(title)
         self.clear()
@@ -233,17 +240,20 @@ class Interface:
 
     @_fullscreen
     @_clean_up_errors
-    def get_quantity(self, max, min, is_float=False, autoround=True, text=None, prompt=None, title=None):
+    def get_quantity(self, max_, min_, is_float=False, autoround=True,
+                     text=None, prompt=None, title=None):
         try:
-            max = float(max) if is_float else int(max)
-            min = float(min) if is_float else int(min)
+            max_ = float(max_) if is_float else int(max_)
+            min_ = float(min_) if is_float else int(min_)
         except ValueError as e:
-            raise InterfaceException("requested a quantity with non-numeric"
-                    " value bounds (value was {0})".format(str(e.args[0])))
+            raise InterfaceException(
+                "requested a quantity with non-numeric value bounds (value "
+                "was {0})".format(str(e.args[0])))
         if prompt:
             self.prompt(prompt)
         else:
-            self.prompt('Enter a whole number between {0} and {1}'.format(min, max))
+            self.prompt(
+                'Enter a whole number between {0} and {1}'.format(min_, max_))
         if title:
             self.title(title)
         if text:
@@ -257,22 +267,26 @@ class Interface:
                 except ValueError:
                     self.error("That's not a number!")
                     continue
-            if q > max:
+            if q > max_:
                 if autoround:
-                    return max
+                    return max_
                 else:
-                    self.error("Too high! Maximum value is {0}".format(str(max)))
-            elif q < min:
+                    self.error(
+                        "Too high! Maximum value is {0}".format(str(max_)))
+            elif q < min_:
                 if autoround:
-                    return min
+                    return min_
                 else:
-                    self.error("Too low! Minimum value is {0}".format(str(min)))
+                    self.error(
+                        "Too low! Minimum value is {0}".format(str(min_)))
             else:
                 return q
+
 
 def _echo(text):
     """Display ``text`` and flush output."""
     sys.stdout.write(u'{}'.format(text))
     sys.stdout.flush()
+
 
 interface = Interface()


### PR DESCRIPTION
A lot of [PEP8](https://www.python.org/dev/peps/pep-0008/) style violations where found, this hopes to fix most of them.

This also renames some variables so they no longer shadow python internal names (```id```, ```min``` and ```max``` where used in a few places as variable names).